### PR TITLE
Clarify message collection comment in reporters

### DIFF
--- a/src/basic/reporters.nim
+++ b/src/basic/reporters.nim
@@ -79,7 +79,8 @@ proc writeMessage(c: var Reporter; k: MsgKind; p: string, args: seq[string]) =
     stdout.styledWriteLine(resetStyle, "")
 
 proc message(c: var Reporter; k: MsgKind; p: string, args: openArray[string]) =
-  ## collects messages or prints them out immediately
+  ## prints messages immediately and does not store them
+  ## uncomment the line below to collect messages instead
   # c.messages.add (k, p, arg)
   if c.assertOnError:
     raise newException(AssertionDefect, p & ": " & $args)


### PR DESCRIPTION
## Summary
- Clarify that `Reporter.message` prints messages immediately and does not store them
- Note that message collection requires uncommenting the `c.messages.add` line

## Testing
- `nimble test -y` *(fails: directory not found: /workspace/atlas/atlas-tests/ws_integration)*

------
https://chatgpt.com/codex/tasks/task_b_6896779409508332b779f9ae227e1dd7