### PR TITLE
Detect Nimble files when auto-initializing projects

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -17,6 +17,7 @@ task unitTests, "Runs unit tests":
   exec "nim c -d:debug -r tests/testtraverse.nim"
   exec "nim c -d:debug -r tests/testsemverUnit.nim"
   exec "nim c -d:debug -r tests/testautoinit.nim"
+  exec "nim c -d:debug -r tests/testsearch.nim"
 
 task tester, "Runs integration tests":
   exec "nim c -d:debug -r tests/tester.nim"

--- a/config.nims
+++ b/config.nims
@@ -16,6 +16,7 @@ task unitTests, "Runs unit tests":
   exec "nim c -d:debug -r tests/tnimbleparser.nim"
   exec "nim c -d:debug -r tests/testtraverse.nim"
   exec "nim c -d:debug -r tests/testsemverUnit.nim"
+  exec "nim c -d:debug -r tests/testautoinit.nim"
 
 task tester, "Runs integration tests":
   exec "nim c -d:debug -r tests/tester.nim"

--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -278,14 +278,16 @@ proc detectProject(customProject = Path ""): bool =
     if result:
       project(project().absolutePath)
 
-proc autoProject(currentDir: Path): bool =
+proc autoProject*(currentDir: Path): bool =
   ## auto detect the project directory
   ##
   ## this will walk the current directory and all of its parents to find a
-  ## directory that contains a git repository
+  ## directory that contains either a git repository or a Nimble file
   var cwd = currentDir
   while cwd.len > 0:
     if dirExists(cwd / Path ".git"):
+      break
+    if findNimbleFile(cwd, "").len > 0:
       break
     cwd = cwd.parentDir()
   project(cwd)

--- a/tests/testautoinit.nim
+++ b/tests/testautoinit.nim
@@ -1,0 +1,19 @@
+import std/[os, paths, unittest]
+import basic/context
+import atlas
+
+template withDir(dir: string; body: untyped) =
+  let old = os.getCurrentDir()
+  try:
+    os.setCurrentDir(dir)
+    body
+  finally:
+    os.setCurrentDir(old)
+
+suite "autoinit":
+  withDir "tests/ws_autoinit":
+    if fileExists("atlas.config"):
+      removeFile("atlas.config")
+    test "detects project with nimble file":
+      check autoProject(os.getCurrentDir().Path)
+      check project() == os.getCurrentDir().Path

--- a/tests/testautoinit.nim
+++ b/tests/testautoinit.nim
@@ -14,6 +14,8 @@ suite "autoinit":
   withDir "tests/ws_autoinit":
     if fileExists("atlas.config"):
       removeFile("atlas.config")
+    if dirExists("deps"):
+      removeDir("deps")
     test "detects project with nimble file":
       check autoProject(os.getCurrentDir().Path)
       check project() == os.getCurrentDir().Path

--- a/tests/testsearch.nim
+++ b/tests/testsearch.nim
@@ -1,0 +1,24 @@
+import std/[os, paths, unittest]
+import basic/context
+import atlas
+
+template withDir(dir: string; body: untyped) =
+  let old = os.getCurrentDir()
+  try:
+    os.setCurrentDir(dir)
+    body
+  finally:
+    os.setCurrentDir(old)
+
+suite "search":
+  withDir "tests":
+    if fileExists("atlas.config"):
+      removeFile("atlas.config")
+    if dirExists("deps"):
+      removeDir("deps")
+    test "runs without project":
+      setContext AtlasContext()
+      atlasRun(@["search", "balls"])
+      check project() == Path("")
+      check not fileExists("atlas.config")
+      check not dirExists("deps")

--- a/tests/testsearch.nims
+++ b/tests/testsearch.nims
@@ -1,0 +1,5 @@
+--noNimblePath
+--path:"../src"
+--path:"$nim"
+--d:atlasStandAlone
+--d:atlasUnitTests

--- a/tests/ws_autoinit/testpkg.nimble
+++ b/tests/ws_autoinit/testpkg.nimble
@@ -1,0 +1,8 @@
+# Package
+version = "0.1.0"
+author = "Tester"
+description = "Dummy project for auto init test"
+license = "MIT"
+
+# Dependencies
+requires "nim >= 2.0.0"


### PR DESCRIPTION
## Summary
- allow `autoProject` to detect directories containing a Nimble file even without a `.git` folder and export it for testing
- add regression test and enable it in the unit test suite

## Testing
- `nim test`


------
https://chatgpt.com/codex/tasks/task_b_68967c93b1c88332a9659677a33ccf4c