### PR TITLE
chore: clean up compiler warnings

### DIFF
--- a/src/atlas.nim
+++ b/src/atlas.nim
@@ -501,10 +501,6 @@ proc atlasRun*(params: seq[string]) =
     elif args.len != 1:
       fatal action & " command takes a single package name"
 
-  template noArgs() =
-    if args.len != 0:
-      fatal action & " command takes no arguments"
-
   parseAtlasOptions(params, action, args)
 
   if action notin ["init", "tag", "search", "list"]:

--- a/src/basic/context.nim
+++ b/src/basic/context.nim
@@ -6,7 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [os, uri, paths, files, tables, sets]
+import std / [uri, paths, files, tables, sets]
 import versions, parse_requires, compiledpatterns, reporters
 
 export reporters
@@ -115,13 +115,3 @@ proc isProject*(dir: Path): bool =
   fileExists(getProjectConfig(dir))
 
 proc `==`*(a, b: CfgPath): bool {.borrow.}
-
-proc displayName(c: AtlasContext; p: string): string =
-  if p == c.projectDir.string:
-    p.absolutePath
-  elif $c.depsDir != "" and p.isRelativeTo($c.depsDir):
-    p.relativePath($c.depsDir)
-  elif p.isRelativeTo($c.projectDir):
-    p.relativePath($c.projectDir)
-  else:
-    p

--- a/src/basic/depgraphtypes.nim
+++ b/src/basic/depgraphtypes.nim
@@ -1,6 +1,6 @@
-import std / [paths, tables, streams, json, jsonutils, sequtils]
+import std / [paths, tables]
 
-import sattypes, context, deptypes, reporters, nimblecontext, pkgurls, versions
+import context, deptypes, pkgurls, versions
 
 
 type 

--- a/src/basic/deptypes.nim
+++ b/src/basic/deptypes.nim
@@ -1,4 +1,4 @@
-import std/[paths, tables, json, jsonutils, hashes, sets]
+import std/[paths, tables, hashes, sets]
 import sattypes, pkgurls, versions, context
 
 export tables

--- a/src/basic/deptypesjson.nim
+++ b/src/basic/deptypesjson.nim
@@ -1,5 +1,5 @@
-import std/[json, jsonutils, paths, strutils, tables, sequtils, sets]
-import sattypes, deptypes, depgraphtypes, nimblecontext, pkgurls, versions, reporters
+import std/[json, jsonutils, paths, strutils, tables, sets]
+import sattypes, deptypes, nimblecontext, pkgurls, versions
 
 export json, jsonutils
 

--- a/src/basic/nimblechecksums.nim
+++ b/src/basic/nimblechecksums.nim
@@ -6,7 +6,8 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [strutils, os, sha1, algorithm]
+import std / [strutils, os, algorithm]
+import checksums / sha1
 import context, osutils
 import gitops
 

--- a/src/basic/pkgurls.nim
+++ b/src/basic/pkgurls.nim
@@ -6,7 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [hashes, uri, os, strutils, files, dirs, sequtils, pegs, json, jsonutils]
+import std / [hashes, uri, os, strutils, files, dirs, sequtils, pegs]
 import gitops, reporters, context
 
 export uri

--- a/src/basic/versions.nim
+++ b/src/basic/versions.nim
@@ -6,8 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [strutils, parseutils, algorithm, jsonutils, hashes]
-import std / json
+import std / [strutils, parseutils, algorithm, hashes]
 
 type
   Version* = distinct string

--- a/src/confighandler.nim
+++ b/src/confighandler.nim
@@ -9,7 +9,7 @@
 ## Configuration handling.
 
 import std / [strutils, os, streams, json, tables, jsonutils, uri, sequtils]
-import basic/[versions, depgraphtypes, nimblecontext, deptypesjson, context, reporters, compiledpatterns, parse_requires, deptypes]
+import basic/[versions, nimblecontext, deptypesjson, context, reporters, compiledpatterns, parse_requires, deptypes]
 
 proc readPluginsDir(dir: Path) =
   for k, f in walkDir($(project() / dir)):

--- a/src/lockfiles.nim
+++ b/src/lockfiles.nim
@@ -119,7 +119,6 @@ proc pinGraph*(graph: DepGraph; lockFile: Path; exportNimble = false) =
     if pkg.isRoot:
       continue
 
-    let dir = pkg.ondisk
     if not exportNimble:
       # generate atlas native lockfile entries
       genLockEntry lf, pkg
@@ -198,8 +197,6 @@ proc listChanged*(lockFile: Path) =
               convertNimbleLock(lockFile)
            else:
               readLockFile(lockFile)
-
-  let base = splitPath(lockFile).head
 
   # update the the dependencies
   for _, v in pairs(lf.items):

--- a/src/nimenv.nim
+++ b/src/nimenv.nim
@@ -82,7 +82,7 @@ proc setupNimEnv*(nimVersion: string; keepCsources: bool) =
         else:
           exec "make"
     let nimExe0 = ".." / csourcesVersion / "bin" / "nim".addFileExt(ExeExt)
-    let dir = Path(depsDir() / nimDest)
+    let dir = depsDir() / nimDest
     withDir $(depsDir() / nimDest):
       let nimExe = "bin" / "nim".addFileExt(ExeExt)
       copyFileWithPermissions nimExe0, nimExe


### PR DESCRIPTION
## Summary
- remove unused imports and dead code across modules
- switch to `checksums/sha1` to avoid deprecated `sha1` warning

## Testing
- `nim build`
- `nim unitTests` *(fails: cannot open file: sat/satvars)*

------
https://chatgpt.com/codex/tasks/task_b_6899dd6d49f083328e9f9aeae7b26923